### PR TITLE
Update workflow to install polytope

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -31,6 +31,9 @@ jobs:
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Install Polytope
+        run: |
+          pip install .
       - name: Test with pytest
         run: |
           python -m pytest


### PR DESCRIPTION
Currently PR checker fails due to "no module named polytope".
Installing the package itself mitigates the problem.