### PR TITLE
Fix pytest error in wsl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,7 @@ pytest = "^7.4.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flake8==3.9.0
-pytest==6.2.5
+pytest==7.4.0
+requests==2.31.0


### PR DESCRIPTION
This revision includes:
* fix `ModuleNotFoundError` in WSL
* update pytest 6.2.5 -> 7.4.0
* add `tool.python.ini_options` on pyproject.toml